### PR TITLE
Remove loop parameter from Queue

### DIFF
--- a/cybroscgiserver/rootfs/usr/local/bin/scgi_server/src/input_output/abus_stack/abus/abus_exchanger.py
+++ b/cybroscgiserver/rootfs/usr/local/bin/scgi_server/src/input_output/abus_stack/abus/abus_exchanger.py
@@ -14,7 +14,7 @@ class AbusExchanger:
 
         # sequence of (request, future) tuples where future will be resolved with future
         # response or error
-        self._requests_queue = asyncio.Queue(loop=self._communication_loop)
+        self._requests_queue = asyncio.Queue()
 
         # holds exchange tag of the most recently sent request. It has to be remembered throughout
         # the read cycle so it can be compared with responses' exchange tags


### PR DESCRIPTION
# Proposed Changes

In python 3.10 the loop parameter for Queue() is deprecated.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
